### PR TITLE
refactor: make I18NExtension.Translate fallback overload return not null

### DIFF
--- a/src/Antelcat.I18N.Shared/I18NExtension.cs
+++ b/src/Antelcat.I18N.Shared/I18NExtension.cs
@@ -40,7 +40,10 @@ public partial class I18NExtension : MarkupExtension, IAddChild
         set => CultureChanged?.Invoke(value);
     }
 
-    public static string? Translate(string key, string? fallbackValue = null) =>
+    public static string? Translate(string key) =>
+        Target.TryGetValue(key, out var value) ? value : null;
+
+    public static string Translate(string key, string fallbackValue) =>
         Target.TryGetValue(key, out var value)
             ? value ?? fallbackValue
             : fallbackValue;


### PR DESCRIPTION
`NotNullIfNotNull` Attribute 仅在 .NET Standard 2.1 可用，但是项目需要支持 .NET Framework，故使用分离两个 overload 的方案。

会破坏 ABI 兼容性，但是不会破坏源代码级别的兼容性。

close #23 